### PR TITLE
Fix. Use access token instead of ID token for Keycloak setup

### DIFF
--- a/avni/src/main/java/org/avni_integration_service/avni/client/AvniSession.java
+++ b/avni/src/main/java/org/avni_integration_service/avni/client/AvniSession.java
@@ -61,7 +61,7 @@ public class AvniSession {
         if (authenticationResultType != null && authenticationResultType.getIdToken() != null && !authenticationResultType.getIdToken().isEmpty()) {
             return authenticationResultType.getIdToken();
         } else if (keycloakResponse != null)
-            return keycloakResponse.getIdToken();
+            return keycloakResponse.getAccessToken();
         return null;
     }
 
@@ -92,7 +92,7 @@ public class AvniSession {
                             entity,
                             KeycloakResponse.class);
             keycloakResponse = responseEntity.getBody();
-            return keycloakResponse.getIdToken();
+            return keycloakResponse.getAccessToken();
         }
     }
 


### PR DESCRIPTION
When Keycloak is used as the IDP type for Avni, API calls complete sucessfully only when access token is used instead of ID token